### PR TITLE
meta.js doesn't use distURLBase correctly

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -1,46 +1,37 @@
-const path = require('path');
-const { pathToFileURL } = require('url');
-const pkg = require('./package.json');
+const path = require("path");
+const { pathToFileURL, URL } = require("url");
+const pkg = require("./package.json");
 
 const distURLBase = `https://example.com/dist`;
 const packageName = pkg.name;
 
 const production = !process.env.ROLLUP_WATCH;
-const baseUrl = !production	? path.join(__dirname, 'dist') : distURLBase;
+const baseUrl = path.join(__dirname, "dist");
 
 let meta = {
-    "name": production ? packageName : packageName + ' -> dev',
-    "version": pkg.version,
-    "description": pkg.description,
-	"homepage": pkg.homepage,
-	"author": pkg.author,
-    "namespace": "https://github.com",
-    "resource": {
-		css: pathToFileURL(path.join(baseUrl, 'bundle.css'))
-	},
-    "match": [
-        "https://*.github.com/*"
-    ],
-    "grant": [
-        "GM_addStyle",
-        "GM_getResourceText",
-        "GM_xmlhttpRequest"
-    ],
-    "connect": [
-        "github.com"
-    ],
-    "run-at": "document-idle"
+  name: production ? packageName : packageName + " -> dev",
+  version: pkg.version,
+  description: pkg.description,
+  homepage: pkg.homepage,
+  author: pkg.author,
+  namespace: "https://github.com",
+  resource: {
+    css: pathToFileURL(path.join(baseUrl, "bundle.css")),
+  },
+  match: ["https://*.github.com/*"],
+  grant: ["GM_addStyle", "GM_getResourceText", "GM_xmlhttpRequest"],
+  connect: ["github.com"],
+  "run-at": "document-idle",
+};
+
+if (!production) {
+  meta.require = [pathToFileURL(path.join(baseUrl, "bundle.js"))];
 }
 
-if(!production){
-	meta.require= [
-        pathToFileURL(path.join(baseUrl, 'bundle.js'))
-    ];
-}
-
-if(production) {
-	meta.downloadURL = pathToFileURL(path.join(baseUrl, 'bundle.js'));
-	meta.updateURL = pathToFileURL(path.join(baseUrl, 'bundle.js'));
+if (production) {
+  meta.downloadURL = new URL("bundle.js", distURLBase);
+  meta.updateURL = new URL("bundle.js", distURLBase);
+  meta.resource.css = new URL("bundle.css", distURLBase);
 }
 
 module.exports = meta;


### PR DESCRIPTION
First, thanks for this awesome template! You really helped me get a personal project off the ground.

I noticed that even after making a production build with `npm run build` that it still produced `file://` URL's in the tampermonkey headers, though.

I don't think this is what you intended. I just realized that my editor reformatted everything, so it's not the cleanest diff in the world. Basically all I changed was to import `URL` and use `new URL()` three times at the bottom of the file.